### PR TITLE
Updated get ROCm bash script

### DIFF
--- a/.github/workflows/amd_pytorch_release.yaml
+++ b/.github/workflows/amd_pytorch_release.yaml
@@ -37,7 +37,7 @@ jobs:
           BUILD_ARGUMENT: "validate-docker-compose-files"
           SRC_APP: "src/demo"
         run: "make -f MakefilePyTorch ${BUILD_ARGUMENT}"
-      - name: Build Base Ubuntu 22.04 image
+      - name: Build Base Ubuntu 20.04 image
         env:
           ROCM_ARCH: "${{ github.event.inputs.ROCM_ARCH }}"
           ROCM_VERSION: "${{ github.event.inputs.ROCM_VERSION }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           BUILD_ARGUMENT: "validate-docker-compose-files"
           SRC_APP: "src/demo"
         run: "make ${BUILD_ARGUMENT}"
-      - name: Build Base Ubuntu 22.04 image
+      - name: Build Base Ubuntu 20.04 image
         env:
           APP_NAME: "base-ubuntu-2004"
           BUILD_ARGUMENT: "build-app-quick"

--- a/get_rocm_version.sh
+++ b/get_rocm_version.sh
@@ -11,5 +11,5 @@ if [ $? -eq 0 ]; then
   fi
   echo $ROCM_VERSION
 else
-  echo ""
+  echo "5.1.3"
 fi

--- a/get_rocm_version.sh
+++ b/get_rocm_version.sh
@@ -5,7 +5,6 @@ ls /opt/rocm/lib/librocm-core.so.* > /dev/null
 if [ $? -eq 0 ]; then
   ROCM_VERSION=$(ls /opt/rocm/lib/librocm-core.so.* | sed -r 's/.*librocm-core\.so\.1\.0\.([0-9]+)/\1/')
   ROCM_VERSION="$(echo $ROCM_VERSION | tr 0 .)"
-  echo "ROCm version is $ROCM_VERSION"
   regexp='^([1-9]+\.[0-9]+)(\.\.)$'
   if [[ $ROCM_VERSION =~ $regexp ]]; then
     ROCM_VERSION=$(echo $ROCM_VERSION | sed -E "s/$regexp/\1.0/g")

--- a/get_rocm_version.sh
+++ b/get_rocm_version.sh
@@ -11,5 +11,5 @@ if [ $? -eq 0 ]; then
   fi
   echo $ROCM_VERSION
 else
-  echo "5.1.3"
+  echo ""
 fi

--- a/get_rocm_version.sh
+++ b/get_rocm_version.sh
@@ -4,7 +4,13 @@ ls /opt/rocm/lib/librocm-core.so.* > /dev/null
 
 if [ $? -eq 0 ]; then
   ROCM_VERSION=$(ls /opt/rocm/lib/librocm-core.so.* | sed -r 's/.*librocm-core\.so\.1\.0\.([0-9]+)/\1/')
-  echo $ROCM_VERSION | tr 0 .
+  ROCM_VERSION="$(echo $ROCM_VERSION | tr 0 .)"
+  echo "ROCm version is $ROCM_VERSION"
+  regexp='^([1-9]+\.[0-9]+)(\.\.)$'
+  if [[ $ROCM_VERSION =~ $regexp ]]; then
+    ROCM_VERSION=$(echo $ROCM_VERSION | sed -E "s/$regexp/\1.0/g")
+  fi
+  echo $ROCM_VERSION
 else
   echo ""
 fi

--- a/get_rocm_version.sh
+++ b/get_rocm_version.sh
@@ -7,7 +7,7 @@ if [ $? -eq 0 ]; then
   ROCM_VERSION="$(echo $ROCM_VERSION | tr 0 .)"
   regexp='^([1-9]+\.[0-9]+)(\.\.)$'
   if [[ $ROCM_VERSION =~ $regexp ]]; then
-    ROCM_VERSION=$(echo $ROCM_VERSION | sed -E "s/$regexp/\1.0/g")
+    ROCM_VERSION=$(echo $ROCM_VERSION | sed -E "s/$regexp/\1/g")
   fi
   echo $ROCM_VERSION
 else


### PR DESCRIPTION
Updated get ROCm bash script to get ROCm version correctly based on
major and minor version and where patch version is 0 aka. no
patches.